### PR TITLE
Add --validate-gpml flag to build_pathways.py; document test_gpml_fil…

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,12 +212,14 @@ It prints a per-file report and a summary at the end (`Total files / Valid / Inv
 ### Recommended workflow
 
 ```
-1. python scripts/validate_plantcyc_input.py <data_dir>   # check input
-2. python scripts/build_pathways.py <data_dir> <out_dir>  # build GPML
-3. python scripts/test_gpml_files.py <out_dir>            # check output
+1. python scripts/validate_plantcyc_input.py <data_dir>              # check input
+2. python scripts/build_pathways.py <data_dir> <out_dir>              # build GPML
+3. python scripts/build_pathways.py <data_dir> <out_dir> --validate-gpml  # build + XSD check in one step
+   # OR separately:
+   python scripts/test_gpml_files.py <out_dir>                        # check output (XSD)
 ```
 
-Resolve all input ERRORs before running the build. Resolve all output validation errors before tagging a release.
+The `--validate-gpml` flag runs `test_gpml_files.py` automatically after the build — the same XSD check the GitHub Actions CI runs on every push. Resolve all input ERRORs before running the build. Resolve all output validation errors before tagging a release.
 
 ---
 
@@ -453,8 +455,9 @@ flowchart TD
         B["2. Build organism mappings\nbuild_org_mapping.py · classes.dat · species.dat"]
         C["3. CompletePathwayBuilderWithGenes\n───────────────────────\nFor each pathway:\n  Expand sub-pathways\n  Collect reactions/compounds/proteins/genes\n  Propagate species to genes (skip cross-species ERROR genes)\n  For CPLX proteins: propagate species to component\n  monomers where they appear as standalone DataNodes\n  Lay out nodes · Create DataNodes + Interactions"]
         D["4. gpml_writer.py\n───────────────────────\nPython objects → GPML2021 XML\nDataNode (GeneProduct/Protein/Metabolite) · Group (Complex)\nAnnotationRef on DataNodes only — Groups: XSD forbids it"]
+        XSD["4b. test_gpml_files.py  (--validate-gpml)\n───────────────────────\nGPML2021 XSD compliance · Duplicate IDs\nMissing cross-refs · Same check as GitHub CI\n✓ 0 errors in current build"]
         S["5. Post-build scripts\n───────────────────────\nanalyze_gpml_stats.py → GPML_STATISTICS_REPORT.txt\ngenerate_species_coverage_table.py →\n  species_coverage_by_ncbi.tsv (Table S1)\n  species_coverage_by_plantcyc_orgid.tsv (Table S2)\n  species_coverage_summary.tsv (incl. only_complex list)\nrun.metadata.txt"]
-        V --> B --> C --> D --> S
+        V --> B --> C --> D --> XSD --> S
     end
 
     A --> MAIN

--- a/scripts/build_pathways.py
+++ b/scripts/build_pathways.py
@@ -18,6 +18,8 @@ Options:
     --pathway-id <PATHWAY_ID>  : Build only a specific pathway by ID
     --reaction-id <REACTION_ID>: Build only a specific reaction by ID
     --db-version <VERSION>     : PlantCyc database version (e.g. 17.0.0)
+    --validate-gpml            : After building, run test_gpml_files.py (GPML2021 XSD
+                                 validation) on the output directory. Same check as CI.
 
 Examples:
     # Build all pathways
@@ -529,6 +531,7 @@ def main():
     output_base_dir = sys.argv[2]
     include_reactions = '--include-reactions' in sys.argv or '--include_reactions' in sys.argv
     no_timestamp_subdir = '--no-timestamp-subdir' in sys.argv or '--no_timestamp_subdir' in sys.argv
+    validate_gpml = '--validate-gpml' in sys.argv
 
     # Parse specific pathway or reaction ID
     specific_pathway_id = None
@@ -857,6 +860,30 @@ def main():
     # scans both individual_pathways/*.gpml AND individual_reactions/*.gpml recursively.
     # Species that only appear in reaction files (no full pathway) are otherwise missed.
     _generate_species_coverage(data_dir, output_dir, output_dir)
+
+    # ── Optional GPML XSD validation ─────────────────────────────────────────
+    # Runs test_gpml_files.py on the output directory when --validate-gpml is set.
+    # This is the same check the GitHub Actions CI runs on every push.
+    if validate_gpml:
+        print("\n" + "="*60)
+        print("RUNNING GPML XSD VALIDATION (test_gpml_files.py)")
+        print("="*60)
+        gpml_validator = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                       "test_gpml_files.py")
+        if os.path.exists(gpml_validator):
+            import subprocess as _sp
+            result = _sp.run([sys.executable, gpml_validator, output_dir],
+                             capture_output=True, text=True, timeout=600)
+            if result.stdout:
+                for line in result.stdout.strip().splitlines()[-20:]:
+                    print(f"  {line}")
+            if result.returncode != 0:
+                print(f"  ⚠ GPML validation found errors (exit {result.returncode}). "
+                      f"See output above.")
+            else:
+                print("  ✓ All GPML files pass XSD validation.")
+        else:
+            print(f"  WARNING: {gpml_validator} not found — skipping GPML validation")
 
     # Print summary to console
     print("\n" + "="*60)


### PR DESCRIPTION
…es.py

build_pathways.py:
  New --validate-gpml flag runs test_gpml_files.py on the output directory
  after the build completes. This is the same XSD check the GitHub Actions
  CI runs on every push — now available locally in one command:
    python scripts/build_pathways.py <data> <out> --include-reactions --validate-gpml

README:
  Recommended workflow updated to show --validate-gpml shorthand.
  Mermaid diagram: added step 4b for test_gpml_files.py with '0 errors'.